### PR TITLE
Nest coordinator routes under role protection

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,12 +21,6 @@ createRoot(document.getElementById('root')!).render(
           <Route path='/login' element={<App />} />
           <Route path="/" element={<PublicRedirect />} />
 
-          <Route element={<CoordenadorLayout />}>
-            <Route path="/home_coordenador" element={<Home />} />
-            <Route path="/criar" element={<CriarUsuario />} />
-            <Route path="/criar-formador" element={<AdicionarFormador />} />
-          </Route>
-
           <Route element={<RoleProtectedLayout allowedRoles={["CHEFEDEPARTAMENTO"]} />}>
             <Route element={<ChefeDepartamentoLayout />}>
                {/* <Route path="/home_chefe" element={<ChefeDashboard />} /> */}
@@ -35,9 +29,11 @@ createRoot(document.getElementById('root')!).render(
           </Route>
 
           <Route element={<RoleProtectedLayout allowedRoles={["COORDENADOR"]} />}>
-            {/* <Route element={<CoordenadorLayout />}>
-              <Route path="/home_coordenador" element={<CoordenadorDashboard />} />
-            </Route> */}
+            <Route element={<CoordenadorLayout />}>
+              <Route path="/home_coordenador" element={<Home />} />
+              <Route path="/criar" element={<CriarUsuario />} />
+              <Route path="/criar-formador" element={<AdicionarFormador />} />
+            </Route>
           </Route>
 
           <Route element={<RoleProtectedLayout allowedRoles={["DIRECTOR"]} />}>


### PR DESCRIPTION
## Summary
- move the coordinator layout and routes inside the role-protected coordinator section
- remove the redundant unprotected coordinator route wrapper

## Testing
- npm run lint *(fails: existing eslint rule configuration complaints in generated .vite deps and shared exports)*

------
https://chatgpt.com/codex/tasks/task_e_68d12fcdb7388328bb29c73d80c4fd12