### PR TITLE
Add role dashboard pages and routes

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,11 @@ import CoordenadorLayout from './components/CoordenadorLayout.tsx'
 import RoleProtectedLayout from './components/RoleProtectedLayout.tsx'
 import DirectorLayout from './components/DirectorLayout.tsx'
 import ChefeDepartamentoLayout from './components/ChefeDepartamentoLayout.tsx'
+import FormadorLayout from './components/FormadorLayout.tsx'
 import PublicRedirect from './pages/PublicRedirect.tsx'
+import ChefeDashboard from './pages/ChefeDashboard.tsx'
+import DirectorDashboard from './pages/DirectorDashboard.tsx'
+import FormadorDashboard from './pages/FormadorDashboard.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -23,7 +27,7 @@ createRoot(document.getElementById('root')!).render(
 
           <Route element={<RoleProtectedLayout allowedRoles={["CHEFEDEPARTAMENTO"]} />}>
             <Route element={<ChefeDepartamentoLayout />}>
-               {/* <Route path="/home_chefe" element={<ChefeDashboard />} /> */}
+              <Route path="/home_chefe" element={<ChefeDashboard />} />
               {/* <Route path="/chefe/relatorios" element={<ChefeRelatorios />} />  */}
             </Route>
           </Route>
@@ -38,14 +42,14 @@ createRoot(document.getElementById('root')!).render(
 
           <Route element={<RoleProtectedLayout allowedRoles={["DIRECTOR"]} />}>
             <Route element={<DirectorLayout />}>
-              {/* <Route path="/home_director" element={<DirectorDashboard />} /> */}
+              <Route path="/home_director" element={<DirectorDashboard />} />
             </Route>
           </Route>
 
           <Route element={<RoleProtectedLayout allowedRoles={["FORMADOR"]} />}>
-            {/* <Route element={<FormadorLayout />}>
+            <Route element={<FormadorLayout />}>
               <Route path="/home_formador" element={<FormadorDashboard />} />
-            </Route> */}
+            </Route>
           </Route>
 
         </Routes>

--- a/src/pages/ChefeDashboard.tsx
+++ b/src/pages/ChefeDashboard.tsx
@@ -1,0 +1,12 @@
+import type { FC } from "react";
+
+const ChefeDashboard: FC = () => {
+    return (
+        <div className="space-y-4">
+            <h1 className="text-2xl font-semibold">Painel do Chefe de Departamento</h1>
+            <p>Bem-vindo! Aqui você poderá gerir relatórios, horários e atividades do departamento.</p>
+        </div>
+    );
+};
+
+export default ChefeDashboard;

--- a/src/pages/DirectorDashboard.tsx
+++ b/src/pages/DirectorDashboard.tsx
@@ -1,0 +1,12 @@
+import type { FC } from "react";
+
+const DirectorDashboard: FC = () => {
+    return (
+        <div className="space-y-4">
+            <h1 className="text-2xl font-semibold">Painel do Diretor</h1>
+            <p>Esta é a área do diretor para acompanhar indicadores e decisões estratégicas.</p>
+        </div>
+    );
+};
+
+export default DirectorDashboard;

--- a/src/pages/FormadorDashboard.tsx
+++ b/src/pages/FormadorDashboard.tsx
@@ -1,0 +1,12 @@
+import type { FC } from "react";
+
+const FormadorDashboard: FC = () => {
+    return (
+        <div className="space-y-4">
+            <h1 className="text-2xl font-semibold">Painel do Formador</h1>
+            <p>Gerencie disponibilidades, horários de aulas e acompanhe notificações importantes.</p>
+        </div>
+    );
+};
+
+export default FormadorDashboard;


### PR DESCRIPTION
## Summary
- add placeholder dashboard pages for chefe, diretor, and formador roles
- register new dashboard routes with the appropriate protected layouts
- ensure the formador layout wraps the formador dashboard route

## Testing
- npm run lint *(fails: existing project lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d13468d8ac8328b52772671aeeb0e9