### PR TITLE
Add unauthorized route and page

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,6 +16,7 @@ import PublicRedirect from './pages/PublicRedirect.tsx'
 import ChefeDashboard from './pages/ChefeDashboard.tsx'
 import DirectorDashboard from './pages/DirectorDashboard.tsx'
 import FormadorDashboard from './pages/FormadorDashboard.tsx'
+import Unauthorized from './pages/Unauthorized.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -24,6 +25,7 @@ createRoot(document.getElementById('root')!).render(
         <Routes>
           <Route path='/login' element={<App />} />
           <Route path="/" element={<PublicRedirect />} />
+          <Route path="/unauthorized" element={<Unauthorized />} />
 
           <Route element={<RoleProtectedLayout allowedRoles={["CHEFEDEPARTAMENTO"]} />}>
             <Route element={<ChefeDepartamentoLayout />}>

--- a/src/pages/Unauthorized.tsx
+++ b/src/pages/Unauthorized.tsx
@@ -1,0 +1,23 @@
+import { Link } from "react-router-dom";
+
+export default function Unauthorized() {
+    return (
+        <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-4 text-center">
+            <section className="space-y-3">
+                <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+                    Acesso não autorizado
+                </h1>
+                <p className="max-w-md text-base text-muted-foreground sm:text-lg">
+                    Não encontramos as permissões necessárias para abrir esta página. Se acredita que isto é um
+                    engano, contacte o administrador do sistema.
+                </p>
+            </section>
+            <Link
+                to="/login"
+                className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90"
+            >
+                Voltar para o início de sessão
+            </Link>
+        </main>
+    );
+}


### PR DESCRIPTION
## Summary
- add a dedicated Unauthorized page with guidance and a link back to the login screen
- register the new page in the router so RoleProtectedLayout redirects land on it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d135ea03148328b3829d98289f51e0